### PR TITLE
use push instead of merge

### DIFF
--- a/.github/workflows/copy_to_dev_branches.yml
+++ b/.github/workflows/copy_to_dev_branches.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: copy core-api spec to dev branch
         env:
-          TARGET_BRANCH: 'origin/core-api'
+          TARGET_BRANCH: 'core-api'
         run: |
           cd ./front-api-specs
           git config user.name github-actions

--- a/.github/workflows/copy_to_dev_branches.yml
+++ b/.github/workflows/copy_to_dev_branches.yml
@@ -24,9 +24,7 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
           git fetch
-          git checkout $TARGET_BRANCH --
-          git merge origin/main
-          git push
+          git push origin main:$TARGET_BRANCH -f
 
       - name: copy channel-api spec to dev branch
         env:
@@ -36,6 +34,4 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
           git fetch
-          git checkout $TARGET_BRANCH --
-          git merge origin/main
-          git push
+          git push origin main:$TARGET_BRANCH -f


### PR DESCRIPTION
There seemed to be a problem with merging master into core-api branch when I updated the docs from the front repo.  I'm not sure if the manual changes to core-api affected this.

However I realized a 'merge' is conceptually bringing together two sources of truth, but that's not really what we're doing here.  We really just want to take main as our single source of truth and copy it completely into the core-api and channel-api branches.  I think this force push from main to the other branches is simpler and actually matches our mental model a little better.