### PR TITLE
Update to rdme10

### DIFF
--- a/.github/workflows/publish_open_api_docs.yml
+++ b/.github/workflows/publish_open_api_docs.yml
@@ -14,11 +14,11 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Sync Public API definition
-        uses: readmeio/rdme@7.2.0
+        uses: readmeio/rdme@v10
         with:
-          rdme: openapi core-api/core-api.json --key=${{ secrets.README_API_KEY }} --id=5e4c9919ca81b300660e92d6
+          rdme: openapi upload core-api/core-api.json --key=${{ secrets.README_API_KEY }}
       
       - name: Sync Channel API definition
-        uses: readmeio/rdme@7.2.0
+        uses: readmeio/rdme@v10
         with:
-          rdme: openapi channel-api/channel-api.json --key=${{ secrets.README_API_KEY }} --id=5e4c9919ca81b300660e92d8
+          rdme: openapi upload channel-api/channel-api.json --key=${{ secrets.README_API_KEY }}


### PR DESCRIPTION
To continue syncing our OpenAPI files to the new Readme Refactored experience, we need to use v10 of the RDME CLI.

I'm upgrading this GitHub action per Readme's [migration guide](https://github.com/readmeio/rdme/blob/next/documentation/migration-guide.md#migrating-to-rdme10):
* Change `openapi` to `openapi upload`
* Remove `id` option given it's unnecessary for version 10
* Bump the required version number