### PR TITLE
Add slug to RDME command

### DIFF
--- a/.github/workflows/publish_open_api_docs.yml
+++ b/.github/workflows/publish_open_api_docs.yml
@@ -16,9 +16,9 @@ jobs:
       - name: Sync Public API definition
         uses: readmeio/rdme@v10
         with:
-          rdme: openapi upload core-api/core-api.json --key=${{ secrets.README_API_KEY }}
+          rdme: openapi upload core-api/core-api.json --slug=core-api.json --key=${{ secrets.README_API_KEY }}
       
       - name: Sync Channel API definition
         uses: readmeio/rdme@v10
         with:
-          rdme: openapi upload channel-api/channel-api.json --key=${{ secrets.README_API_KEY }}
+          rdme: openapi upload channel-api/channel-api.json --slug=channel-api.json --key=${{ secrets.README_API_KEY }}


### PR DESCRIPTION
Add the slug parameter to the RMDE upload command. This should hopefully fix the issue with duplicate API specs being created in our docs versus the changes updating the existing spec.