### PR TITLE
SEC-704: Pin all actions

### DIFF
--- a/.github/workflows/copy_to_dev_branches.yml
+++ b/.github/workflows/copy_to_dev_branches.yml
@@ -12,7 +12,7 @@ jobs:
       
     steps:
       - name: checkout front-api-specs repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           path: ./front-api-specs
 

--- a/.github/workflows/publish_open_api_docs.yml
+++ b/.github/workflows/publish_open_api_docs.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps: 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Sync Public API definition
-        uses: readmeio/rdme@v10
+        uses: readmeio/rdme@e15cd5a73726f1c5a753e3bcce8eb07c42e8d567
         with:
           rdme: openapi upload core-api/core-api.json --slug=core-api.json --key=${{ secrets.README_API_KEY }}
       
       - name: Sync Channel API definition
-        uses: readmeio/rdme@v10
+        uses: readmeio/rdme@e15cd5a73726f1c5a753e3bcce8eb07c42e8d567
         with:
           rdme: openapi upload channel-api/channel-api.json --slug=channel-api.json --key=${{ secrets.README_API_KEY }}


### PR DESCRIPTION
https://front.atlassian.net/browse/SEC-704
Now that we have allowlisted all existing GH actions, we should work to pin all to a full length SHA commit as a security measure in response to the tj-actions incident.

Safe to revert.