### PR TITLE
Expect lowercase value, as the API returns them

### DIFF
--- a/core-api/core-api.json
+++ b/core-api/core-api.json
@@ -5201,9 +5201,9 @@
               "visitor",
               "rule",
               "macro",
-              "API",
+              "api",
               "integration",
-              "CSAT"
+              "csat"
             ]
           },
           "custom_fields": {


### PR DESCRIPTION
Our PHP library generated based on these specs throws an exception because the value returned by the API (lowercase `api`) doesn't match any of the enum values (which is defined as `API`). As these two are the only enum values in the whole API definition, I'm quite confident it must be a mistake.